### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -23,10 +23,10 @@ setStartAngle	KEYWORD2
 registerErrorCallback	KEYWORD2
 getResponseFromCmd	KEYWORD2
 getResponseFromCmdUntil	KEYWORD2
-on_off_motor  KEYWORD2
-set_ch_pos_spd  KEYWORD2 
-get_current_pos  KEYWORD2
-set_ch_initial_pos  KEYWORD2
+on_off_motor	KEYWORD2
+set_ch_pos_spd	KEYWORD2 
+get_current_pos	KEYWORD2
+set_ch_initial_pos	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords